### PR TITLE
Do not merge:  Revert "Use LegacyStrings to support UFT16String"

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.4
+julia 0.3
 HDF5
 JLD
-LegacyStrings # for julia-0.5

--- a/test/v0.4.jl
+++ b/test/v0.4.jl
@@ -1,4 +1,4 @@
-using HDF5, JLD, Base.Test, Compat, LegacyStrings
+using HDF5, JLD, Base.Test, Compat
 import Compat.String
 
 # Define variables of different types


### PR DESCRIPTION
Testing, do not merge

This reverts commit fdf3a727a977a654eb750375188c0d83f01f6349.