### PR TITLE
Fixes for julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.6
 HDF5
-JLD v0.6.8
+JLD 0.6.8
+Compat 0.48
 LegacyStrings # for julia-0.5


### PR DESCRIPTION
This is coordinated with https://github.com/JuliaIO/JLD.jl/pull/215.

I've had to disable a few tests here as well, mostly for the same reasons as detailed in the JLD PR (alignment issues with mmap, a problem with a struct containing a union of bitskind types).

Additionally, there are two new issues:

1. the representation of `Expr` has changed in 0.7, the field `typ` was removed
2. the representation of `Char` was also changed, so that the bits stored in old archives are now interpreted differently.

All disabled tests are marked with FIXME comments.
Any pointers on how to fix the above mentioned issues would be appreciated. Alternatively, this PR might be merged and the issues fixed by someone more knowledgeable than me.
